### PR TITLE
Add dummy DCO workflow for merge queues

### DIFF
--- a/.github/workflows/dco-merge-queue.yml
+++ b/.github/workflows/dco-merge-queue.yml
@@ -1,0 +1,11 @@
+# Based on https://github.com/hyperledger/besu/pull/5207/files
+name: DCO
+on:
+  merge_group:
+
+jobs:
+  DCO:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - run: echo "This DCO job runs on merge_queue event and doesn't check PR contents"


### PR DESCRIPTION
This is needed because the DCO app doesn't support merge queues. We already know the DCO was checked before being queued, so we can ignore it for merge queues.
