### PR TITLE
Fix potential remote code execution issues

### DIFF
--- a/.github/workflows/dco-merge-queue.yml
+++ b/.github/workflows/dco-merge-queue.yml
@@ -3,6 +3,8 @@ name: DCO
 on:
   merge_group:
 
+permissions: {}
+
 jobs:
   DCO:
     runs-on: ubuntu-latest

--- a/action.yaml
+++ b/action.yaml
@@ -36,7 +36,9 @@ runs:
     - name: Install the dependencies
       shell: bash
       if: ${{ inputs.dependencies != '' }}
-      run: python -m pip install ${{ inputs.dependencies }}
+      env:
+        DEPENDENCIES: ${{ inputs.dependencies }}
+      run: echo "$DEPENDENCIES" | xargs python -m pip install
 
     - name: Print the installed dependencies (debug)
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -31,16 +31,16 @@ runs:
 
     - name: Upgrade pip
       shell: bash
-      run: python -m pip install --upgrade pip
+      run: python -I -m pip install --upgrade pip
 
     - name: Install the dependencies
       shell: bash
       if: ${{ inputs.dependencies != '' }}
       env:
         DEPENDENCIES: ${{ inputs.dependencies }}
-      run: echo "$DEPENDENCIES" | xargs python -m pip install
+      run: echo "$DEPENDENCIES" | xargs python -I -m pip install
 
     - name: Print the installed dependencies (debug)
       shell: bash
       if: ${{ inputs.dependencies != '' }}
-      run: python -m pip freeze
+      run: python -I -m pip freeze


### PR DESCRIPTION
This PR addresses potential vulnerabilities that could lead to remote code execution when the action is used in workflows triggered by `pull_request_target` where the repository code is checked out.

1. Python Path Hijacking: Changed all `python -m pip` commands to use the isolated mode flag (`python -I -m pip`). This prevents malicious local files like `pip.py` from shadowing the legitimate pip module and being executed when the command runs.
2. Shell Injection: Moved the `${{ inputs.dependencies }}` interpolation from the bash command line into an intermediate environment variable `$DEPENDENCIES`. This prevents potential shell injection if an attacker manages to control the dependencies input.
