### PR TITLE
Fix glob expansion for local dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Python
-        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
+        uses: frequenz-floss/gh-action-setup-python-with-deps@bc560ff517d3606e1291eed46a603a9f7bfe8697 # v1.0.3
         with:
           python-version: "3.11"
           dependencies: "mkdocs"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,35 @@ jobs:
    This is passed to the
    [`actions/setup-python`](https://github.com/actions/setup-python) action.
 
-* `dependencies`: The dependencies to install. Default: "".
+* `dependencies`: The dependencies to install. Default: `""`.
 
-  This is passed to the `pip install` command as is, without any shell
-  escaping. If empty, no dependencies are installed. 
+  A whitespace-separated list of dependencies passed to `pip install`. If empty,
+  no dependencies are installed.
+
+  **Supported:**
+
+  - Standard package names and version specifiers (e.g., `pytest`,
+    `requests>=2.0`, `mkdocs[all]`).
+  - Local wheel files (`.whl`), including safe glob patterns (e.g.,
+    `dist/*.whl`).
+
+  **Not Supported (Blocked for Security):**
+  To prevent arbitrary code execution from untrusted checked-out code in
+  `pull_request_target` workflows, the following are explicitly blocked:
+
+  - Editable installs (`-e`, `--editable`).
+  - Requirement files (`-r`, `--requirement`).
+  - Constraint files (`-c`, `--constraint`).
+  - Local source directory installations (e.g., `.`, `./pkg`).
+  - Local source distributions (`.tar.gz`, `.zip`).
+  - Local file URLs (`file://`).
+
+  **Security Features:**
+
+  - **Safe Execution:** This action runs Python in isolated mode (`python -I`),
+    which ignores the current working directory. This prevents path hijacking
+    attacks where a malicious `pip.py` could shadow the legitimate `pip`
+    module.
+  - **Safe Argument Parsing:** The `dependencies` input is parsed and
+    glob-expanded safely without shell `eval` or interpolation, preventing
+    shell command injection.

--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,7 @@ runs:
       if: ${{ inputs.dependencies != '' }}
       env:
         DEPENDENCIES: ${{ inputs.dependencies }}
-      run: echo "$DEPENDENCIES" | xargs python -I -m pip install
+      run: ${{ github.action_path }}/scripts/install-dependencies.sh
 
     - name: Print the installed dependencies (debug)
       shell: bash

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+set -euo pipefail
+
+# This script safely installs pip dependencies.
+# It expects the DEPENDENCIES environment variable to be set.
+# It splits the dependencies, expands globs for local wheel files,
+# and explicitly blocks unsafe local dependency sources like editable
+# installs or requirement files, ensuring no arbitrary code execution
+# from checked-out repositories.
+
+if [ -z "${DEPENDENCIES:-}" ]; then
+	echo "No dependencies provided."
+	exit 0
+fi
+
+# We use read to split DEPENDENCIES on whitespace into an array
+read -r -a raw_args <<<"$DEPENDENCIES"
+
+args=()
+for arg in "${raw_args[@]}"; do
+	# Block unsafe arguments
+	case "$arg" in
+	-e | -e* | --editable | --editable=* | -r | -r* | --requirement | --requirement=* | -c | -c* | --constraint | --constraint=*)
+		echo "::error::Unsupported pip option in dependencies: $arg"
+		echo "::error::This action refuses editable installs, requirement files, and constraint files to avoid executing checked-out code."
+		exit 1
+		;;
+	file:* | file://*)
+		echo "::error::Local file URLs are not allowed in dependencies: $arg"
+		exit 1
+		;;
+	esac
+
+	is_path_like=false
+	case "$arg" in
+	. | ./* | ../* | /* | */* | *.whl | *.tar.gz | *.zip)
+		is_path_like=true
+		;;
+	esac
+
+	has_glob=false
+	case "$arg" in
+	*'*'* | *'?'*)
+		# Note: '[' is intentionally excluded from glob detection because it
+		# is used in Python extras syntax (e.g. requests[security], .[dev,test])
+		# and character-class globs like [abc] are not a realistic use case here.
+		has_glob=true
+		;;
+	esac
+
+	# Handle glob expansion for path-like arguments
+	if [ "$is_path_like" = true ] && [ "$has_glob" = true ]; then
+		matches=()
+		while IFS= read -r match; do
+			if [ -n "$match" ]; then
+				matches+=("$match")
+			fi
+		done < <(compgen -G "$arg" || true)
+
+		if [ "${#matches[@]}" -eq 0 ]; then
+			# No match found, just pass the literal arg (pip will likely fail, which is fine)
+			args+=("$arg")
+			continue
+		fi
+
+		for match in "${matches[@]}"; do
+			case "$match" in
+			*.whl)
+				args+=("$match")
+				;;
+			*)
+				echo "::error::Only local wheel files may be installed from the checkout: $match"
+				exit 1
+				;;
+			esac
+		done
+		continue
+	fi
+
+	# Handle literal path-like arguments
+	if [ "$is_path_like" = true ]; then
+		case "$arg" in
+		*.whl)
+			args+=("$arg")
+			;;
+		*)
+			echo "::error::Only local wheel files may be installed from the checkout: $arg"
+			exit 1
+			;;
+		esac
+		continue
+	fi
+
+	# Regular package specifier or flag
+	args+=("$arg")
+done
+
+echo "Running: python -I -m pip install ${args[*]}"
+python -I -m pip install "${args[@]}"


### PR DESCRIPTION
Using `xargs` to safely parse the `DEPENDENCIES` environment variable prevented the shell from expanding globs (e.g., `dist/*.whl`). This broke workflows that relied on wildcard patterns for passing locally built wheel files to `pip`.

This commit delegates the installation step to a companion script `scripts/install-dependencies.sh`. This script safely splits the arguments, explicitly handles glob expansions for paths (restoring the `*.whl` support), and proactively blocks unsafe dependencies (like editable installs or requirement files) to ensure arbitrary code execution from the checked-out PR context remains prevented.
