### PR TITLE
Fix Windows action script path

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,11 @@ runs:
       if: ${{ inputs.dependencies != '' }}
       env:
         DEPENDENCIES: ${{ inputs.dependencies }}
-      run: ${{ github.action_path }}/scripts/install-dependencies.sh
+      # Use $GITHUB_ACTION_PATH (runtime expansion) rather than interpolating
+      # ${{ github.action_path }}: on Windows the latter pastes backslashes into
+      # the script source which bash strips, breaking the path.
+      run: |
+        "$GITHUB_ACTION_PATH/scripts/install-dependencies.sh"
 
     - name: Print the installed dependencies (debug)
       shell: bash


### PR DESCRIPTION
On Windows, `github.action_path` expands to a path with backslashes. Interpolating it directly into a bash `run` step makes bash consume those backslashes while parsing the generated script, producing an invalid path.

Use `$GITHUB_ACTION_PATH` so the path is expanded from the environment at runtime, after bash has tokenized the wrapper script.

Fixes #22.
